### PR TITLE
Allow fonts to be loaded from Stream

### DIFF
--- a/Una.Drawing/src/DrawingLib.cs
+++ b/Una.Drawing/src/DrawingLib.cs
@@ -39,7 +39,7 @@ public class DrawingLib
         // as it supports a wide range of characters, including Japanese.
         FontRegistry.SetNativeFontFamily(
             0,
-            new(
+            new FileInfo(
                 Path.Combine(
                     pluginInterface.DalamudAssetDirectory.FullName,
                     "UIRes",
@@ -51,7 +51,7 @@ public class DrawingLib
 
         FontRegistry.SetNativeFontFamily(
             1,
-            new(
+            new FileInfo(
                 Path.Combine(
                     pluginInterface.DalamudAssetDirectory.FullName,
                     "UIRes",
@@ -63,7 +63,7 @@ public class DrawingLib
 
         FontRegistry.SetNativeFontFamily(
             2,
-            new(
+            new FileInfo(
                 Path.Combine(
                     pluginInterface.DalamudAssetDirectory.FullName,
                     "UIRes",

--- a/Una.Drawing/src/Font/FontFactory.cs
+++ b/Una.Drawing/src/Font/FontFactory.cs
@@ -34,4 +34,9 @@ internal class FontFactory
     {
         return new DynamicFont(SKTypeface.FromFile(file.FullName), FontRegistry.Glyphs, sizeOffset);
     }
+
+    internal static IFont CreateFromFontStream(Stream stream, float sizeOffset)
+    {
+        return new DynamicFont(SKTypeface.FromStream(stream), FontRegistry.Glyphs, sizeOffset);
+    }
 }

--- a/Una.Drawing/src/Font/FontRegistry.cs
+++ b/Una.Drawing/src/Font/FontRegistry.cs
@@ -77,6 +77,28 @@ public static class FontRegistry
         FontChanged?.Invoke();
     }
 
+    /// <summary>
+    /// Creates a font from the given font file stream and registers it with the
+    /// given ID. Existing fonts with the same ID will be disposed of.
+    /// </summary>
+    /// <example>
+    /// Register: <code>FontRegistry.SetNativeFontFamily(1, stream);</code>
+    /// Usage: <code>new Style() { Font = 1 }</code>
+    /// </example>
+    /// <param name="id"></param>
+    /// <param name="fontStream"></param>
+    /// <param name="sizeOffset"></param>
+    /// <exception cref="FileNotFoundException"></exception>
+    public static void SetNativeFontFamily(uint id, Stream fontStream, float sizeOffset = 0)
+    {
+        if (!fontStream.CanRead) throw new EndOfStreamException($"The stream for font #{id} is not readable.");
+
+        if (Fonts.TryGetValue(id, out IFont? existingFont)) existingFont.Dispose();
+
+        Fonts[id] = FontFactory.CreateFromFontStream(fontStream, sizeOffset);
+        FontChanged?.Invoke();
+    }
+
     internal static void SetupGlyphFont()
     {
         Glyphs = SKTypeface.FromFile(GameGlyphProvider.GlyphsFile.FullName);


### PR DESCRIPTION
This PR adds the ability to add fonts via streams, allowing us to use a manifest resource stream to load embedded resources.

Example usage:
```cs
public void RegisterFontAsset(uint id, string name)
{
    var resourceName = $"PluginAssemblyName.Assets.{name}.ttf";

    var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName)
        ?? throw new FileNotFoundException("ManifestResource not found", resourceName);

    FontRegistry.SetNativeFontFamily(id, stream, 0);
}
```