### PR TITLE
Do not wait for GC when the games framework is unloading

### DIFF
--- a/Una.Drawing/src/DrawingLib.cs
+++ b/Una.Drawing/src/DrawingLib.cs
@@ -116,8 +116,10 @@ public class DrawingLib
         UdtLoader.Dispose();
 
         // Force the GC to run to clean up any remaining resources.
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
+        if (!DalamudServices.Framework.IsFrameworkUnloading) {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
     }
 
     private static void OnDraw()


### PR DESCRIPTION
It doesn't make much sense to wait for GC, since the process is ending anyways.
Makes Dalamud unload a bit faster. 😅