### PR TITLE
Ignore VanillaPlus overlays

### DIFF
--- a/Una.Drawing/src/Clipping/ClipRectProvider.cs
+++ b/Una.Drawing/src/Clipping/ClipRectProvider.cs
@@ -100,6 +100,7 @@ public static class ClipRectProvider
 
             string? name = unit->NameString;
             if (name is "_FocusTargetInfo" or "JobHudNotice") continue;
+            if (name != null && name.StartsWith("KTK_Overlay")) continue;
 
             iterator((IntPtr)unit, name ?? string.Empty);
         }

--- a/Una.Drawing/src/Clipping/ClipRectProvider.cs
+++ b/Una.Drawing/src/Clipping/ClipRectProvider.cs
@@ -100,6 +100,8 @@ public static class ClipRectProvider
 
             string? name = unit->NameString;
             if (name is "_FocusTargetInfo" or "JobHudNotice") continue;
+            
+            // Ignore VanillaPlus "OverlayController" which is not visible on screen
             if (name != null && name.StartsWith("KTK_Overlay")) continue;
 
             iterator((IntPtr)unit, name ?? string.Empty);


### PR DESCRIPTION
This caused issues in Umbra where markers would disappear, as markers would mistakenly considered as clipping through a rectangle and thus hidden.

This does not affect regular windows from VanillaPlus nor the game itself (thanks to the very specific node name prefix)